### PR TITLE
Remove combiner adjustments (transparency fix)

### DIFF
--- a/SM64Paint/ROMManager.cs
+++ b/SM64Paint/ROMManager.cs
@@ -127,22 +127,7 @@ public class ROMManager
 
     public static void AdjustCombiners()
     {
-        if (GeoLayouts.AlphaModels.Length < 1) return;
-        for (uint i = 0; i < GeoLayouts.AlphaModels.Length; i++)
-        {
-            uint addr = GeoLayouts.AlphaModels[i];
-            uint endaddr = 0;
-            for (uint j = addr; j < SM64ROM.getEndROMAddr(); j += 8)
-            {
-                if (SM64ROM.getByte(j) == 0xB8) { endaddr = j + 8; break; }
-            }
-            for (uint j = addr; j < SM64ROM.getEndROMAddr(); j += 8)
-            {
-                if (SM64ROM.getByte(j) == 0xFB) SM64ROM.WriteEightBytes(j, 0xE700000000000000); //Get rid of env colour combiners
-                else if (SM64ROM.getByte(j) == 0xFC && SM64ROM.ReadEightBytes(j) == 0xFC122E24FFFFFBFD) SM64ROM.WriteEightBytes(j, 0xFC121824FF33FFFF); //Fix combiner
-                else if (SM64ROM.getByte(j) == 0xB8) break;
-            }
-        }
+        // One duck cries when your transparency disappears
     }
 
     public static bool LevelHasLighting()


### PR DESCRIPTION
Combiner fixes kill transparency on normal textures (32x32). Even if transparent CI4 textures won't work, killing transparency as a whole is not good. Screenshots: 
![1](https://user-images.githubusercontent.com/6104625/39268145-ad134932-48d7-11e8-903a-91d5f0e6742d.png)
![2](https://user-images.githubusercontent.com/6104625/39268146-ad2e969c-48d7-11e8-9e02-3cd4ab984cd6.png)
This commit just removes all combiner adjustments which might not be overall a good decision but it is a way out :] All CI4 textures does work fine
